### PR TITLE
Added new formula field to sort news list on home page 

### DIFF
--- a/force-app/main/default/objects/NKS_Announcement__c/fields/NKS_News_Sorting_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/NKS_Announcement__c/fields/NKS_News_Sorting_Date__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NKS_News_Sorting_Date__c</fullName>
+    <description>Formula field to sort News feed on home page.</description>
+    <externalId>false</externalId>
+    <formula>IF( NKS_News_Update_Date__c  &gt;  NKS_News_Publish_Date__c  , NKS_News_Update_Date__c, NKS_News_Publish_Date__c)</formula>
+    <label>News Sorting Date</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION
Det er ønskelig å sortere nyhetslisten først etter festede nyheter og deretter etter dato for publisering. Hvis en nyhet blir oppdatert skal den komme opp på listen uten å være behov for festing. Det nye formelfeltet er opprettet for å håndtere denne sorteringen.