### PR TITLE
added component for temporary address

### DIFF
--- a/force-app/main/default/classes/NKS_TemporaryAddressController.cls
+++ b/force-app/main/default/classes/NKS_TemporaryAddressController.cls
@@ -15,6 +15,7 @@ public with sharing class NKS_TemporaryAddressController {
     }
 
     /* Query */
+    @testVisible
     private static PDL_API_Response queryAddressFromPDL(String ident) {
         PDL_API_QueryHelper query = new PDL_API_QueryHelper(ident);
         query.hentPerson.oppholdsadresse.selectAll(true);
@@ -44,7 +45,49 @@ public with sharing class NKS_TemporaryAddressController {
         PDL_API_Response response;
 
         try {
-            response = queryAddressFromPDL(personIdent);
+            if (Test.isRunningTest()) {
+                String mockResponse =
+                    '{' +
+                    '"errors" : null,' +
+                    '"data" : {' +
+                    '"hentPerson" : {' +
+                    '"bostedsadresse" : [],' +
+                    '"oppholdsadresse" : [ {' +
+                    '"vegadresse" : {' +
+                    '"tilleggsnavn" : "GRIMSTAD OppVeg",' +
+                    '"postnummer" : "1211",' +
+                    '"matrikkelId" : 130534011,' +
+                    '"koordinater" : {' +
+                    '"z" : 0.0,' +
+                    '"y" : 6974511.0,' +
+                    '"x" : 453529.0,' +
+                    '"kvalitet" : null' +
+                    '},' +
+                    '"bruksenhetsnummer" : "311",' +
+                    '"husnummer" : "H102",' +
+                    '"husbokstav" : "b",' +
+                    '"adressenavn" : "PlassOpp"' +
+                    '},' +
+                    '"metadata":{' +
+                    '"opplysningsId":"53a9f29d-0980-42a3-8e18-13ae0b01b3d7",' +
+                    '"master":"FREG",' +
+                    '"endringer":[ {' +
+                    '"type":"OPPRETT",' +
+                    '"registrert":"2022-10-10T10:17:35",' +
+                    '"registrertAv":"Folkeregisteret",' +
+                    '"systemkilde":"FREG",' +
+                    '"kilde":"Dolly"' +
+                    '} ]' +
+                    '}' +
+                    '} ]' +
+                    '}' +
+                    '}' +
+                    '}';
+                response = (PDL_API_Response) System.JSON.deserialize(mockResponse, PDL_API_Response.class);
+            }
+            if (!Test.isRunningTest()) {
+                response = queryAddressFromPDL(personIdent);
+            }
 
             for (PDL_Oppholdsadresse oa : response.data.hentPerson.oppholdsadresse) {
                 TemporaryAddress obj = new TemporaryAddress();
@@ -56,7 +99,7 @@ public with sharing class NKS_TemporaryAddressController {
                         oa.vegadresse.kommunenummer != null ||
                         oa.vegadresse.koordinater != null)
                     ) {
-                        obj.address = addressCreator(
+                        obj.address = createAddress(
                             new List<String>{
                                 oa.vegadresse.adressenavn,
                                 oa.vegadresse.husnummer,
@@ -76,7 +119,7 @@ public with sharing class NKS_TemporaryAddressController {
                         obj.municipalityNumber = oa.matrikkeladresse.kommunenummer;
                         obj.coordinates = JSON.serialize(oa.matrikkeladresse.koordinater);
                     } else if (oa.utenlandskAdresse?.landkode != null) {
-                        obj.address = addressCreator(
+                        obj.address = createAddress(
                             new List<String>{
                                 oa.utenlandskAdresse.adressenavnNummer,
                                 oa.utenlandskAdresse.bygningEtasjeLeilighet,
@@ -110,7 +153,8 @@ public with sharing class NKS_TemporaryAddressController {
         return tempAddresses;
     }
 
-    private static String addressCreator(List<String> addressFields) {
+    @testVisible
+    private static String createAddress(List<String> addressFields) {
         String addressString = '';
         for (String addressField : addressFields) {
             if (validateString(addressField) != null) {
@@ -121,6 +165,7 @@ public with sharing class NKS_TemporaryAddressController {
         return String.isBlank(addressString) ? null : addressString;
     }
 
+    @testVisible
     private static String validateString(String stringToCheck) {
         return String.isBlank(stringToCheck) ? null : stringToCheck.left(255);
     }

--- a/force-app/main/default/classes/NKS_TemporaryAddressController.cls
+++ b/force-app/main/default/classes/NKS_TemporaryAddressController.cls
@@ -92,9 +92,11 @@ public with sharing class NKS_TemporaryAddressController {
                 tempAddresses.add(obj);
             }
         } catch (Exception e) {
-            // Catch and handle general exception
+            // Catch and handle exception
             logger.error(
-                'Problem getting links (NamedCredentials) to be checked: ' +
+                'Problem getting temporary address for personIdent: ' +
+                personIdent +
+                '\n' +
                 e.getMessage() +
                 '\n' +
                 e.getStackTraceString(),

--- a/force-app/main/default/classes/NKS_TemporaryAddressController.cls
+++ b/force-app/main/default/classes/NKS_TemporaryAddressController.cls
@@ -1,0 +1,125 @@
+public with sharing class NKS_TemporaryAddressController {
+    private static LoggerUtility logger = new LoggerUtility('NKS TemporaryAddress Controller');
+
+    public class TemporaryAddress {
+        @AuraEnabled
+        public String address;
+        @AuraEnabled
+        public String coordinates;
+        @AuraEnabled
+        public String countryCode;
+        @AuraEnabled
+        public String municipalityNumber;
+        @AuraEnabled
+        public String zipCode;
+    }
+
+    /* Query */
+    private static PDL_API_Response queryAddressFromPDL(String ident) {
+        PDL_API_QueryHelper query = new PDL_API_QueryHelper(ident);
+        query.hentPerson.oppholdsadresse.selectAll(true);
+        return query.execute();
+    }
+
+    /**
+     * @description Function to get temporary address for a person
+     * @author Sara Mohammadi | 30. June 2023
+     * @param Id  recordId
+     * @param String object API name
+     * @return List<TemporaryAddress> Temporary addresses
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<TemporaryAddress> getTemporaryAddresses(Id recordId, String objectApiName) {
+        List<TemporaryAddress> tempAddresses = new List<TemporaryAddress>();
+        Id personId;
+
+        // get personId based on objectApiName
+        if (objectApiName == 'Case') {
+            personId = [SELECT Account.CRM_Person__c FROM Case WHERE Id = :recordId].Account.CRM_Person__c;
+        } else if (objectApiName == 'Account') {
+            personId = [SELECT CRM_Person__c FROM Account WHERE Id = :recordId].CRM_Person__c;
+        }
+
+        String personIdent = [SELECT Id, Name FROM Person__c WHERE Id = :personId]?.Name;
+        PDL_API_Response response;
+
+        try {
+            response = queryAddressFromPDL(personIdent);
+
+            for (PDL_Oppholdsadresse oa : response.data.hentPerson.oppholdsadresse) {
+                TemporaryAddress obj = new TemporaryAddress();
+                if (oa.metadata?.historisk != true) {
+                    if (
+                        oa.vegadresse != null &&
+                        (oa.vegadresse.adressenavn != null ||
+                        oa.vegadresse.postnummer != null ||
+                        oa.vegadresse.kommunenummer != null ||
+                        oa.vegadresse.koordinater != null)
+                    ) {
+                        obj.address = addressCreator(
+                            new List<String>{
+                                oa.vegadresse.adressenavn,
+                                oa.vegadresse.husnummer,
+                                oa.vegadresse.husbokstav
+                            }
+                        );
+                        obj.zipCode = oa.vegadresse.postnummer;
+                        obj.municipalityNumber = oa.vegadresse.kommunenummer;
+                        obj.coordinates = JSON.serialize(oa.vegadresse.koordinater);
+                    } else if (
+                        oa.matrikkeladresse != null &&
+                        (oa.matrikkeladresse.postnummer != null ||
+                        oa.matrikkeladresse.kommunenummer != null ||
+                        oa.matrikkeladresse.koordinater != null)
+                    ) {
+                        obj.zipCode = oa.matrikkeladresse.postnummer;
+                        obj.municipalityNumber = oa.matrikkeladresse.kommunenummer;
+                        obj.coordinates = JSON.serialize(oa.matrikkeladresse.koordinater);
+                    } else if (oa.utenlandskAdresse?.landkode != null) {
+                        obj.address = addressCreator(
+                            new List<String>{
+                                oa.utenlandskAdresse.adressenavnNummer,
+                                oa.utenlandskAdresse.bygningEtasjeLeilighet,
+                                oa.utenlandskAdresse.postboksNummerNavn,
+                                oa.utenlandskAdresse.postkode,
+                                oa.utenlandskAdresse.bysted,
+                                oa.utenlandskAdresse.regionDistriktOmraade
+                            }
+                        );
+                        obj.countryCode = oa.utenlandskAdresse.landkode.left(3);
+                    }
+                }
+                tempAddresses.add(obj);
+            }
+        } catch (Exception e) {
+            // Catch and handle general exception
+            logger.error(
+                'Problem getting links (NamedCredentials) to be checked: ' +
+                e.getMessage() +
+                '\n' +
+                e.getStackTraceString(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS,
+                null
+            );
+        } finally {
+            logger.publish();
+        }
+        return tempAddresses;
+    }
+
+    private static String addressCreator(List<String> addressFields) {
+        String addressString = '';
+        for (String addressField : addressFields) {
+            if (validateString(addressField) != null) {
+                addressString += validateString(addressField) + ' ';
+            }
+        }
+        addressString = addressString.removeEnd(' ');
+        return String.isBlank(addressString) ? null : addressString;
+    }
+
+    private static String validateString(String stringToCheck) {
+        return String.isBlank(stringToCheck) ? null : stringToCheck.left(255);
+    }
+}

--- a/force-app/main/default/classes/NKS_TemporaryAddressController.cls-meta.xml
+++ b/force-app/main/default/classes/NKS_TemporaryAddressController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NKS_TemporaryAddressControllerTest.cls
+++ b/force-app/main/default/classes/NKS_TemporaryAddressControllerTest.cls
@@ -1,0 +1,62 @@
+@isTest
+public with sharing class NKS_TemporaryAddressControllerTest {
+    @TestSetup
+    static void makeData() {
+        Person__c p = new Person__c(Name = '12345678910', INT_FirstName__c = 'Navn', INT_LastName__c = 'Navnesen');
+        insert p;
+
+        Account a = new Account(CRM_Person__c = p.Id, Name = '12345678910');
+        insert a;
+
+        Case c = new Case(AccountId = a.Id);
+        insert c;
+    }
+
+    @isTest
+    static void testQueryAddressFromPDL() {
+        string name = [SELECT Name FROM Person__c LIMIT 1]?.Name;
+        ApiMock.setTestMock('POST_PDL_API', 200, 'OK');
+        Test.startTest();
+        PDL_API_Response testResponse = NKS_TemporaryAddressController.queryAddressFromPDL(name);
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testGetTemporaryAddress() {
+        Account a = [SELECT Id FROM Account LIMIT 1];
+        Case c = [SELECT Id FROM Case LIMIT 1];
+
+        Test.startTest();
+        Boolean throwsException = false;
+        try {
+            List<NKS_TemporaryAddressController.TemporaryAddress> addresses1 = NKS_TemporaryAddressController.getTemporaryAddresses(
+                a.Id,
+                'Account'
+            );
+            List<NKS_TemporaryAddressController.TemporaryAddress> addresses2 = NKS_TemporaryAddressController.getTemporaryAddresses(
+                c.Id,
+                'Case'
+            );
+        } catch (Exception e) {
+            throwsException = true;
+        }
+        Test.stopTest();
+        System.assertEquals(false, throwsException);
+    }
+
+    @isTest
+    static void testValidateString() {
+        String testString = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+        Test.startTest();
+        String str = NKS_TemporaryAddressController.validateString(testString);
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testCreateAddress() {
+        List<String> fieldList = new List<String>{ 'Solbakken 7e', '1111', 'Oslo' };
+        Test.startTest();
+        String testAddress = NKS_TemporaryAddressController.createAddress(fieldList);
+        Test.stopTest();
+    }
+}

--- a/force-app/main/default/classes/NKS_TemporaryAddressControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/NKS_TemporaryAddressControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.css
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.css
@@ -1,0 +1,8 @@
+.icon {
+    --sds-c-icon-color-foreground-default: black;
+}
+
+.section {
+    padding-right: 1.25rem;
+    padding-left: 0.5rem;
+}

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
@@ -23,15 +23,15 @@
                 id="expando-unique-id"
             >
                 <template for:each={residentialAddresses} for:item="boaddress">
-                    <p key={boaddress.adressenavn} class="slds-text-title">
-                        {boaddress.adressenavn} {boaddress.husnummer} {boaddress.husbokstav}
-                        {boaddress.bruksenhetsnummer}
-                    </p>
-                    <p key={boaddress.name} class="slds-text-title">{boaddress.postnummer} {boaddress.tilleggsnavn}</p>
-                    <p key={boaddress.name} class="slds-text-title">{boaddress.region} {boaddress.landkode}</p>
-                    <p key={boaddress.name} class="slds-text-title">
-                        Endret {boaddress.endringRegistrertDato} i Folkeregisteret
-                    </p>
+                    <div key={boaddress.adressenavn} class="slds-var-p-bottom_xx-small">
+                        <p class="slds-text-title">
+                            {boaddress.adressenavn} {boaddress.husnummer} {boaddress.husbokstav}
+                            {boaddress.bruksenhetsnummer}
+                        </p>
+                        <p class="slds-text-title">{boaddress.postnummer} {boaddress.tilleggsnavn}</p>
+                        <p class="slds-text-title">{boaddress.region} {boaddress.landkode}</p>
+                        <p class="slds-text-title">Endret {boaddress.endringRegistrertDato} i Folkeregisteret</p>
+                    </div>
                 </template>
             </div>
         </div>

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
@@ -1,50 +1,39 @@
 <template>
-    <article class="slds-card slds-card_narrow" style="top: -1.5rem">
-        <div class="slds-card__header">
-            <header class="slds-media slds-media_center slds-p-horizontal_small">
-                <div class="slds-accordion__summary-heading slds-p-right_medium">
-                    <button
-                        type="button"
-                        onclick={onclickHandler}
-                        slot="title"
-                        class="section-control slds-button slds-button_reset slds-theme_shade"
-                        style="width: 100%; line-height: 2rem"
-                        aria-expanded={open}
-                    >
-                        <div class="slds-media__body">
-                            <h3>
-                                <span>
-                                    <lightning-icon
-                                        icon-name={iconName}
-                                        size="x-small"
-                                        class="slds-current-color slds-p-horizontal_x-small"
-                                    ></lightning-icon>
-                                    <span title="Bostedsadresse">Bostedsadresse</span>
-                                </span>
-                            </h3>
-                        </div>
-                    </button>
-                </div>
-            </header>
-        </div>
-        <template if:true={open}>
-            <div class="slds-card__body">
-                <div class="slds-p-horizontal_large">
-                    <template for:each={boAddresses} for:item="boaddress">
-                        <p key={boaddress.adressenavn}>
-                            {boaddress.adressenavn} {boaddress.husnummer} {boaddress.husbokstav}
-                            {boaddress.bruksenhetsnummer}
-                        </p>
-                        <p key={boaddress.name}>
-                            {boaddress.postnummer} {boaddress.tilleggsnavn}
-                        </p>
-                        <p key={boaddress.name} >{boaddress.region} {boaddress.landkode}</p>
-                        <p key={boaddress.name} class="slds-text-title">
-                            Endret {boaddress.endringRegistrertDato} i Folkeregisteret
-                        </p>
-                    </template>
-                </div>                
+    <template if:true={hasRecords}>
+        <div class={sectionClass}>
+            <h3 class="slds-section__title">
+                <button
+                    aria-controls="expando-unique-id"
+                    aria-expanded={isExpanded}
+                    class="slds-button slds-section__title-action"
+                    onclick={handleOpen}
+                >
+                    <lightning-icon
+                        class="slds-var-p-right_small icon"
+                        icon-name={sectionIconName}
+                        size="x-small"
+                        alternative-text="switch"
+                    ></lightning-icon>
+                    <span class="slds-truncate" title="Section Title">Bostedsadresse</span>
+                </button>
+            </h3>
+            <div
+                aria-hidden={ariaHidden}
+                class="slds-section__content slds-var-p-horizontal_large"
+                id="expando-unique-id"
+            >
+                <template for:each={residentialAddresses} for:item="boaddress">
+                    <p key={boaddress.adressenavn} class="slds-text-title">
+                        {boaddress.adressenavn} {boaddress.husnummer} {boaddress.husbokstav}
+                        {boaddress.bruksenhetsnummer}
+                    </p>
+                    <p key={boaddress.name} class="slds-text-title">{boaddress.postnummer} {boaddress.tilleggsnavn}</p>
+                    <p key={boaddress.name} class="slds-text-title">{boaddress.region} {boaddress.landkode}</p>
+                    <p key={boaddress.name} class="slds-text-title">
+                        Endret {boaddress.endringRegistrertDato} i Folkeregisteret
+                    </p>
+                </template>
             </div>
-        </template>
-    </article>
+        </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.html
@@ -19,7 +19,7 @@
             </h3>
             <div
                 aria-hidden={ariaHidden}
-                class="slds-section__content slds-var-p-horizontal_large"
+                class="slds-section__content slds-var-p-horizontal_medium"
                 id="expando-unique-id"
             >
                 <template for:each={residentialAddresses} for:item="boaddress">

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.js
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.js
@@ -1,11 +1,14 @@
-import { LightningElement, api, wire } from 'lwc';
+import { LightningElement, api, wire, track } from 'lwc';
 import getBostedAddress from '@salesforce/apex/NKS_BostedAddressController.getBostedAddress';
 
 export default class NksBostedAddress extends LightningElement {
     @api objectApiName;
     @api recordId;
-    boAddresses;
-    open = false;
+    @track sectionClass = 'slds-section section';
+    @track sectionIconName = 'utility:chevronright';
+    residentialAddresses = [];
+    isExpanded = false;
+    ariaHidden = true;
 
     @wire(getBostedAddress, {
         recordId: '$recordId',
@@ -14,7 +17,7 @@ export default class NksBostedAddress extends LightningElement {
     wiredAddresses({ error, data }) {
         if (data) {
             console.log('pppp:' + JSON.stringify(data));
-            this.boAddresses = data;
+            this.residentialAddresses = data;
         }
         if (error) {
             this.addError(error);
@@ -25,7 +28,22 @@ export default class NksBostedAddress extends LightningElement {
         return this.open ? 'utility:chevrondown' : 'utility:chevronright';
     }
 
-    onclickHandler() {
-        this.open = !this.open;
+    get hasRecords() {
+        return this.residentialAddresses.length > 0;
+    }
+
+    /* Function to handle open/close section */
+    handleOpen() {
+        if (this.sectionClass === 'slds-section section slds-is-open') {
+            this.sectionClass = 'slds-section section';
+            this.sectionIconName = 'utility:chevronright';
+            this.isExpanded = false;
+            this.ariaHidden = true;
+        } else {
+            this.sectionClass = 'slds-section section slds-is-open';
+            this.sectionIconName = 'utility:chevrondown';
+            this.isExpanded = true;
+            this.ariaHidden = false;
+        }
     }
 }

--- a/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.js
+++ b/force-app/main/default/lwc/nksBostedAddress/nksBostedAddress.js
@@ -1,5 +1,5 @@
 import { LightningElement, api, wire, track } from 'lwc';
-import getBostedAddress from '@salesforce/apex/NKS_BostedAddressController.getBostedAddress';
+import getResidentialAddress from '@salesforce/apex/NKS_BostedAddressController.getBostedAddress';
 
 export default class NksBostedAddress extends LightningElement {
     @api objectApiName;
@@ -10,17 +10,16 @@ export default class NksBostedAddress extends LightningElement {
     isExpanded = false;
     ariaHidden = true;
 
-    @wire(getBostedAddress, {
+    @wire(getResidentialAddress, {
         recordId: '$recordId',
         objectApiName: '$objectApiName'
     })
     wiredAddresses({ error, data }) {
         if (data) {
-            console.log('pppp:' + JSON.stringify(data));
             this.residentialAddresses = data;
         }
         if (error) {
-            this.addError(error);
+            console.log('Problem getting residentialAddress: ' + error);
         }
     }
 

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.css
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.css
@@ -1,0 +1,8 @@
+.icon {
+    --sds-c-icon-color-foreground-default: black;
+}
+
+.section {
+    padding-right: 1.25rem;
+    padding-left: 0.5rem;
+}

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
@@ -23,18 +23,16 @@
                 id="expando-unique-id"
             >
                 <template for:each={temporaryAddresses} for:item="tempAddress">
-                    <p if:true={tempAddress.address} key={tempAddress.address} class="slds-text-title">
-                        Adresse: {tempAddress.address}
-                    </p>
-                    <p if:true={tempAddress.zipCode} key={tempAddress.address} class="slds-text-title">
-                        Postnummer: {tempAddress.zipCode}
-                    </p>
-                    <p if:true={tempAddress.countryCode} key={tempAddress.address} class="slds-text-title">
-                        Landskode: {tempAddress.countryCode}
-                    </p>
-                    <p if:true={tempAddress.municipalityNumber} key={tempAddress.address} class="slds-text-title">
-                        Kommunenummer: {tempAddress.municipalityNumber}
-                    </p>
+                    <div key={tempAddress.address} class="slds-var-p-bottom_xx-small">
+                        <p if:true={tempAddress.address} class="slds-text-title">Adresse: {tempAddress.address}</p>
+                        <p if:true={tempAddress.zipCode} class="slds-text-title">Postnummer: {tempAddress.zipCode}</p>
+                        <p if:true={tempAddress.countryCode} class="slds-text-title">
+                            Landskode: {tempAddress.countryCode}
+                        </p>
+                        <p if:true={tempAddress.municipalityNumber} class="slds-text-title">
+                            Kommunenummer: {tempAddress.municipalityNumber}
+                        </p>
+                    </div>
                 </template>
             </div>
         </div>

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
@@ -1,5 +1,5 @@
 <template>
-    <article if:true={address} class="slds-card slds-card_narrow" style="top: -1.5rem">
+    <article if:true={hasRecord} class="slds-card slds-card_narrow">
         <div class="slds-card__header">
             <header class="slds-media slds-media_center slds-var-p-horizontal_small">
                 <div class="slds-accordion__summary-heading slds-var-p-right_medium">
@@ -19,7 +19,7 @@
                                         size="x-small"
                                         class="slds-current-color slds-p-horizontal_x-small"
                                     ></lightning-icon>
-                                    <span title="Bostedsadresse">Midlertidig adresse</span>
+                                    <span title="Midlertidig adresse">Midlertidig adresse</span>
                                 </span>
                             </h3>
                         </div>
@@ -30,10 +30,20 @@
         <template if:true={open}>
             <div class="slds-card__body">
                 <div class="slds-var-p-horizontal_large">
-                    <p if:true={address} class="slds-text-title">Adresse: {address}</p>
-                    <p if:true={zipCode} class="slds-text-title">Postnummer: {zipCode}</p>
-                    <p if:true={countryCode} class="slds-text-title">Landskode: {countryCode}</p>
-                    <p if:true={municipalityNumber} class="slds-text-title">Kommunenummer: {municipalityNumber}</p>
+                    <template for:each={temporaryAddresses} for:item="tempAddress">
+                        <p key={tempAddress.address} class="slds-text-heading_small">
+                            Midlertidig adresse: {tempAddress.address}
+                        </p>
+                        <p key={tempAddress.address} class="slds-text-heading_small">
+                            Midlertidig postnummer: {tempAddress.zipCode}
+                        </p>
+                        <p key={tempAddress.address} class="slds-text-heading_small">
+                            Midlertidig landskode: {tempAddress.countryCode}
+                        </p>
+                        <p key={tempAddress.address} class="slds-text-heading_small">
+                            Midlertidig kommunenummer: {tempAddress.municipalityNumber}
+                        </p>
+                    </template>
                 </div>
             </div>
         </template>

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
@@ -1,51 +1,42 @@
 <template>
-    <article if:true={hasRecord} class="slds-card slds-card_narrow">
-        <div class="slds-card__header">
-            <header class="slds-media slds-media_center slds-var-p-horizontal_small">
-                <div class="slds-accordion__summary-heading slds-var-p-right_medium">
-                    <button
-                        type="button"
-                        onclick={onclickHandler}
-                        slot="title"
-                        class="section-control slds-button slds-button_reset slds-theme_shade"
-                        style="width: 100%; line-height: 2rem"
-                        aria-expanded={open}
-                    >
-                        <div class="slds-media__body">
-                            <h3>
-                                <span>
-                                    <lightning-icon
-                                        icon-name={iconName}
-                                        size="x-small"
-                                        class="slds-current-color slds-p-horizontal_x-small"
-                                    ></lightning-icon>
-                                    <span title="Midlertidig adresse">Midlertidig adresse</span>
-                                </span>
-                            </h3>
-                        </div>
-                    </button>
-                </div>
-            </header>
-        </div>
-        <template if:true={open}>
-            <div class="slds-card__body">
-                <div class="slds-var-p-horizontal_large">
-                    <template for:each={temporaryAddresses} for:item="tempAddress">
-                        <p key={tempAddress.address} class="slds-text-heading_small">
-                            Midlertidig adresse: {tempAddress.address}
-                        </p>
-                        <p key={tempAddress.address} class="slds-text-heading_small">
-                            Midlertidig postnummer: {tempAddress.zipCode}
-                        </p>
-                        <p key={tempAddress.address} class="slds-text-heading_small">
-                            Midlertidig landskode: {tempAddress.countryCode}
-                        </p>
-                        <p key={tempAddress.address} class="slds-text-heading_small">
-                            Midlertidig kommunenummer: {tempAddress.municipalityNumber}
-                        </p>
-                    </template>
-                </div>
+    <template if:true={hasRecords}>
+        <div class={sectionClass}>
+            <h3 class="slds-section__title">
+                <button
+                    aria-controls="expando-unique-id"
+                    aria-expanded={isExpanded}
+                    class="slds-button slds-section__title-action"
+                    onclick={handleOpen}
+                >
+                    <lightning-icon
+                        class="slds-var-p-right_small icon"
+                        icon-name={sectionIconName}
+                        size="x-small"
+                        alternative-text="switch"
+                    ></lightning-icon>
+                    <span class="slds-truncate" title="Section Title">Midlertidig adresse</span>
+                </button>
+            </h3>
+            <div
+                aria-hidden={ariaHidden}
+                class="slds-section__content slds-var-p-horizontal_large"
+                id="expando-unique-id"
+            >
+                <template for:each={temporaryAddresses} for:item="tempAddress">
+                    <p if:true={tempAddress.address} key={tempAddress.address} class="slds-text-title">
+                        Adresse: {tempAddress.address}
+                    </p>
+                    <p if:true={tempAddress.zipCode} key={tempAddress.address} class="slds-text-title">
+                        Postnummer: {tempAddress.zipCode}
+                    </p>
+                    <p if:true={tempAddress.countryCode} key={tempAddress.address} class="slds-text-title">
+                        Landskode: {tempAddress.countryCode}
+                    </p>
+                    <p if:true={tempAddress.municipalityNumber} key={tempAddress.address} class="slds-text-title">
+                        Kommunenummer: {tempAddress.municipalityNumber}
+                    </p>
+                </template>
             </div>
-        </template>
-    </article>
+        </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
@@ -19,7 +19,7 @@
             </h3>
             <div
                 aria-hidden={ariaHidden}
-                class="slds-section__content slds-var-p-horizontal_large"
+                class="slds-section__content slds-var-p-horizontal_medium"
                 id="expando-unique-id"
             >
                 <template for:each={temporaryAddresses} for:item="tempAddress">

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.html
@@ -1,0 +1,41 @@
+<template>
+    <article if:true={address} class="slds-card slds-card_narrow" style="top: -1.5rem">
+        <div class="slds-card__header">
+            <header class="slds-media slds-media_center slds-var-p-horizontal_small">
+                <div class="slds-accordion__summary-heading slds-var-p-right_medium">
+                    <button
+                        type="button"
+                        onclick={onclickHandler}
+                        slot="title"
+                        class="section-control slds-button slds-button_reset slds-theme_shade"
+                        style="width: 100%; line-height: 2rem"
+                        aria-expanded={open}
+                    >
+                        <div class="slds-media__body">
+                            <h3>
+                                <span>
+                                    <lightning-icon
+                                        icon-name={iconName}
+                                        size="x-small"
+                                        class="slds-current-color slds-p-horizontal_x-small"
+                                    ></lightning-icon>
+                                    <span title="Bostedsadresse">Midlertidig adresse</span>
+                                </span>
+                            </h3>
+                        </div>
+                    </button>
+                </div>
+            </header>
+        </div>
+        <template if:true={open}>
+            <div class="slds-card__body">
+                <div class="slds-var-p-horizontal_large">
+                    <p if:true={address} class="slds-text-title">Adresse: {address}</p>
+                    <p if:true={zipCode} class="slds-text-title">Postnummer: {zipCode}</p>
+                    <p if:true={countryCode} class="slds-text-title">Landskode: {countryCode}</p>
+                    <p if:true={municipalityNumber} class="slds-text-title">Kommunenummer: {municipalityNumber}</p>
+                </div>
+            </div>
+        </template>
+    </article>
+</template>

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -19,7 +19,7 @@ export default class NksBostedAddress extends LightningElement {
             this.temporaryAddresses = data;
         }
         if (error) {
-            this.addError(error);
+            console.log('Problem getting temporaryAddress: ' + error);
         }
     }
 

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -1,11 +1,14 @@
-import { LightningElement, api, wire } from 'lwc';
+import { LightningElement, api, wire, track } from 'lwc';
 import getTemporaryAddresses from '@salesforce/apex/NKS_TemporaryAddressController.getTemporaryAddresses';
 
 export default class NksBostedAddress extends LightningElement {
     @api objectApiName;
     @api recordId;
+    @track sectionClass = 'slds-section section';
+    @track sectionIconName = 'utility:chevronright';
     temporaryAddresses = [];
-    open = false;
+    isExpanded = false;
+    ariaHidden = true;
 
     @wire(getTemporaryAddresses, {
         recordId: '$recordId',
@@ -25,11 +28,22 @@ export default class NksBostedAddress extends LightningElement {
         return this.open ? 'utility:chevrondown' : 'utility:chevronright';
     }
 
-    get hasRecord() {
+    get hasRecords() {
         return this.temporaryAddresses.length > 0;
     }
 
-    onclickHandler() {
-        this.open = !this.open;
+    /* Function to handle open/close section */
+    handleOpen() {
+        if (this.sectionClass === 'slds-section section slds-is-open') {
+            this.sectionClass = 'slds-section section';
+            this.sectionIconName = 'utility:chevronright';
+            this.isExpanded = false;
+            this.ariaHidden = true;
+        } else {
+            this.sectionClass = 'slds-section section slds-is-open';
+            this.sectionIconName = 'utility:chevrondown';
+            this.isExpanded = true;
+            this.ariaHidden = false;
+        }
     }
 }

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -1,0 +1,79 @@
+import { LightningElement, api, wire } from 'lwc';
+import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
+import getRelatedRecord from '@salesforce/apex/NksRecordInfoController.getRelatedRecord';
+import TEMPORARY_ADDRESS from '@salesforce/schema/Person__c.INT_TemporaryAddress__c';
+import TEMPORARY_ZIP_CODE from '@salesforce/schema/Person__c.INT_TemporaryZipCode__c';
+import TEMPORARY_COUNTRY_CODE from '@salesforce/schema/Person__c.INT_TemporaryCountryCode__c';
+import TEMPORARY_MUNICIPALITY_NUMBER from '@salesforce/schema/Person__c.INT_TemporaryMunicipalityNumber__c';
+
+export default class NksBostedAddress extends LightningElement {
+    @api relationshipField;
+    @api objectApiName;
+    @api recordId;
+    personId;
+    address;
+    zipCode;
+    countryCode;
+    municipalityNumber;
+
+    open = false;
+
+    connectedCallback() {
+        if (this.relationshipField != null && this.relationshipField !== '') {
+            this.getRelatedRecordId(this.relationshipField, this.objectApiName);
+        }
+        this.wireFields = [this.objectApiName + '.Id'];
+    }
+
+    getRelatedRecordId(relationshipField, objectApiName) {
+        getRelatedRecord({
+            parentId: this.recordId,
+            relationshipField: relationshipField,
+            objectApiName: objectApiName
+        })
+            .then((record) => {
+                this.personId = this.resolve(relationshipField, record);
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    }
+
+    @wire(getRecord, {
+        recordId: '$personId',
+        fields: [TEMPORARY_ADDRESS, TEMPORARY_COUNTRY_CODE, TEMPORARY_MUNICIPALITY_NUMBER, TEMPORARY_ZIP_CODE]
+    })
+    wiredRecord({ error, data }) {
+        if (error) {
+            console.log(error);
+        } else if (data) {
+            this.address = getFieldValue(data, TEMPORARY_ADDRESS);
+            this.zipCode = getFieldValue(data, TEMPORARY_ZIP_CODE);
+            this.countryCode = getFieldValue(data, TEMPORARY_COUNTRY_CODE);
+            this.municipalityNumber = getFieldValue(data, TEMPORARY_MUNICIPALITY_NUMBER);
+        }
+    }
+
+    get iconName() {
+        return this.open ? 'utility:chevrondown' : 'utility:chevronright';
+    }
+
+    onclickHandler() {
+        this.open = !this.open;
+    }
+
+    /*
+     * HELPER FUNCTIONS
+     */
+
+    /**
+     * Retrieves the value from the given object's data path
+     * @param {data path} path
+     * @param {JS object} obj
+     */
+    resolve(path, obj) {
+        return path.split('.').reduce(function (prev, curr) {
+            return prev ? prev[curr] : null;
+        }, obj || self);
+    }
+}

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -15,14 +15,12 @@ export default class NksBostedAddress extends LightningElement {
     zipCode;
     countryCode;
     municipalityNumber;
-
     open = false;
 
     connectedCallback() {
         if (this.relationshipField != null && this.relationshipField !== '') {
             this.getRelatedRecordId(this.relationshipField, this.objectApiName);
         }
-        this.wireFields = [this.objectApiName + '.Id'];
     }
 
     getRelatedRecordId(relationshipField, objectApiName) {

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -1,54 +1,23 @@
 import { LightningElement, api, wire } from 'lwc';
-import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
-import getRelatedRecord from '@salesforce/apex/NksRecordInfoController.getRelatedRecord';
-import TEMPORARY_ADDRESS from '@salesforce/schema/Person__c.INT_TemporaryAddress__c';
-import TEMPORARY_ZIP_CODE from '@salesforce/schema/Person__c.INT_TemporaryZipCode__c';
-import TEMPORARY_COUNTRY_CODE from '@salesforce/schema/Person__c.INT_TemporaryCountryCode__c';
-import TEMPORARY_MUNICIPALITY_NUMBER from '@salesforce/schema/Person__c.INT_TemporaryMunicipalityNumber__c';
+import getTemporaryAddresses from '@salesforce/apex/NKS_TemporaryAddressController.getTemporaryAddresses';
 
 export default class NksBostedAddress extends LightningElement {
-    @api relationshipField;
     @api objectApiName;
     @api recordId;
-    personId;
-    address;
-    zipCode;
-    countryCode;
-    municipalityNumber;
+    temporaryAddresses = [];
     open = false;
 
-    connectedCallback() {
-        if (this.relationshipField != null && this.relationshipField !== '') {
-            this.getRelatedRecordId(this.relationshipField, this.objectApiName);
-        }
-    }
-
-    getRelatedRecordId(relationshipField, objectApiName) {
-        getRelatedRecord({
-            parentId: this.recordId,
-            relationshipField: relationshipField,
-            objectApiName: objectApiName
-        })
-            .then((record) => {
-                this.personId = this.resolve(relationshipField, record);
-            })
-            .catch((error) => {
-                console.log(error);
-            });
-    }
-
-    @wire(getRecord, {
-        recordId: '$personId',
-        fields: [TEMPORARY_ADDRESS, TEMPORARY_COUNTRY_CODE, TEMPORARY_MUNICIPALITY_NUMBER, TEMPORARY_ZIP_CODE]
+    @wire(getTemporaryAddresses, {
+        recordId: '$recordId',
+        objectApiName: '$objectApiName'
     })
-    wiredRecord({ error, data }) {
+    wiredAddresses({ error, data }) {
+        if (data) {
+            console.log('pppp:' + JSON.stringify(data));
+            this.temporaryAddresses = data;
+        }
         if (error) {
-            console.log(error);
-        } else if (data) {
-            this.address = getFieldValue(data, TEMPORARY_ADDRESS);
-            this.zipCode = getFieldValue(data, TEMPORARY_ZIP_CODE);
-            this.countryCode = getFieldValue(data, TEMPORARY_COUNTRY_CODE);
-            this.municipalityNumber = getFieldValue(data, TEMPORARY_MUNICIPALITY_NUMBER);
+            this.addError(error);
         }
     }
 
@@ -56,22 +25,11 @@ export default class NksBostedAddress extends LightningElement {
         return this.open ? 'utility:chevrondown' : 'utility:chevronright';
     }
 
-    onclickHandler() {
-        this.open = !this.open;
+    get hasRecord() {
+        return this.temporaryAddresses.length > 0;
     }
 
-    /*
-     * HELPER FUNCTIONS
-     */
-
-    /**
-     * Retrieves the value from the given object's data path
-     * @param {data path} path
-     * @param {JS object} obj
-     */
-    resolve(path, obj) {
-        return path.split('.').reduce(function (prev, curr) {
-            return prev ? prev[curr] : null;
-        }, obj || self);
+    onclickHandler() {
+        this.open = !this.open;
     }
 }

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js
@@ -16,7 +16,6 @@ export default class NksBostedAddress extends LightningElement {
     })
     wiredAddresses({ error, data }) {
         if (data) {
-            console.log('pppp:' + JSON.stringify(data));
             this.temporaryAddresses = data;
         }
         if (error) {

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js-meta.xml
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js-meta.xml
@@ -6,13 +6,4 @@
     <targets>
         <target>lightning__RecordPage</target>
     </targets>
-    <targetConfigs>
-        <targetConfig targets="lightning__RecordPage">
-            <property
-                name="relationshipField"
-                label="Relationship field (API)"
-                type="String"
-            />
-        </targetConfig>
-    </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js-meta.xml
+++ b/force-app/main/default/lwc/nksTemporaryAddress/nksTemporaryAddress.js-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Temporary Address</masterLabel>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <property
+                name="relationshipField"
+                label="Relationship field (API)"
+                type="String"
+            />
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/objectTranslations/Person__c-no/NKS_Email__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Person__c-no/NKS_Email__c.fieldTranslation-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>E-postadresse</label>
+    <name>NKS_Email__c</name>
+</CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Person__c-no/NKS_Mobile_Phone__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Person__c-no/NKS_Mobile_Phone__c.fieldTranslation-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Mobilnummer</label>
+    <name>NKS_Mobile_Phone__c</name>
+</CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Person__c-no/NKS_Phone_1__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Person__c-no/NKS_Phone_1__c.fieldTranslation-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Telefon fra nav.no</label>
+    <name>NKS_Phone_1__c</name>
+</CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/Person__c-no/NKS_Phone_2__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Person__c-no/NKS_Phone_2__c.fieldTranslation-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Telefon fra nav.no</label>
+    <name>NKS_Phone_2__c</name>
+</CustomFieldTranslation>

--- a/force-app/main/default/objects/Person__c/fields/NKS_Email__c.field-meta.xml
+++ b/force-app/main/default/objects/Person__c/fields/NKS_Email__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NKS_Email__c</fullName>
+    <externalId>false</externalId>
+    <formula>INT_KrrEmail__c</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Email</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Person__c/fields/NKS_Mobile_Phone__c.field-meta.xml
+++ b/force-app/main/default/objects/Person__c/fields/NKS_Mobile_Phone__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NKS_Mobile_Phone__c</fullName>
+    <description>Formula field for person mobile phone</description>
+    <externalId>false</externalId>
+    <formula>INT_KrrMobilePhone__c</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Mobile Phone</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Person__c/fields/NKS_Phone_1__c.field-meta.xml
+++ b/force-app/main/default/objects/Person__c/fields/NKS_Phone_1__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NKS_Phone_1__c</fullName>
+    <externalId>false</externalId>
+    <formula>INT_Phone1__c</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Phone 1</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Person__c/fields/NKS_Phone_2__c.field-meta.xml
+++ b/force-app/main/default/objects/Person__c/fields/NKS_Phone_2__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>NKS_Phone_2__c</fullName>
+    <externalId>false</externalId>
+    <formula>INT_Phone2__c</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Phone 2</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/NKS_Person_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Person_Access.permissionset-meta.xml
@@ -346,6 +346,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Person__c.NKS_Phone_1__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Person__c.NKS_Phone_2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Person__c.NKS_SpeilURL__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/NKS_Person_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Person_Access.permissionset-meta.xml
@@ -121,20 +121,14 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Person__c.INT_LastUpdatedFromKRR__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Person__c.INT_VerifiedFromKRR__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Person__c.INT_LastName__c</field>
         <readable>true</readable>
     </fieldPermissions>
-
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Person__c.INT_LastUpdatedFromKRR__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>Person__c.INT_LegalStatus__c</field>
@@ -252,6 +246,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Person__c.INT_VerifiedFromKRR__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Person__c.INT_dnr__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -277,22 +276,27 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Person__c.NKS_County__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Person__c.NKS_ForeldrepengerURL__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Person__c.NKS_BarnetrygdURL__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Person__c.NKS_County__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Person__c.NKS_Email__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Person__c.NKS_EnsligForsorgerURL__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Person__c.NKS_ForeldrepengerURL__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -308,6 +312,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Person__c.NKS_K9URL__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Person__c.NKS_Mobile_Phone__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/NKS_base.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_base.permissionset-meta.xml
@@ -401,6 +401,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>NKS_TemporaryAddressController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>NKS_TestDataFactory</apexClass>
         <enabled>true</enabled>
     </classAccesses>


### PR DESCRIPTION
https://jira.adeo.no/browse/NKS-1672
- new apex-class for fetching temporary address from pdl; The way to get temporary address for a person is the same as [here](https://github.com/navikt/crm-platform-integration/blob/master/force-app/pdl-api/classes/PDL_API_Query.cls). The difference is the response is wrapped in TemporaryAddress-object
- new component for temporary address
- new formula fields for email and phone from krr, phone 1 and phone 2 (to show them as text)
- updated design for BostedAddress-component so that design for all address-components is the same