### PR TITLE
removed brukervarsel integration and added tests for brukernotifikasjoner

### DIFF
--- a/force-app/brukervarsel/classes/NKS_BrukervarselController.cls
+++ b/force-app/brukervarsel/classes/NKS_BrukervarselController.cls
@@ -1,46 +1,5 @@
 public with sharing class NKS_BrukervarselController {
     @AuraEnabled(cacheable=true)
-    public static List<NKS_BrukervarslingBestilling> getBrukerVarselFromActorId(
-        String actorId,
-        Date fromDate,
-        Date toDate
-    ) {
-        HttpResponse response = NKS_BrukervarselService.getBrukerVarslerFromActorId(actorId, fromDate, toDate);
-
-        Integer statusCode = response.getStatusCode();
-
-        if (statusCode == 200) {
-            return (List<NKS_BrukervarslingBestilling>) JSON.deserialize(
-                response.getBody(),
-                List<NKS_BrukervarslingBestilling>.class
-            );
-        } else {
-            LoggerUtility logger = new LoggerUtility();
-            logger.error('Error retrieving brukervarsel \n ' + 'Status: ' + response.getStatus(), null);
-            logger.publish();
-
-            if (statusCode == 401) {
-                throw new AuraHandledException('Feil med tilganger mot baksystem');
-            } else if (statusCode == 500) {
-                throw new AuraHandledException(
-                    'Feil ved henting av brukervarsel (' +
-                    'Status: ' +
-                    response.getStatus() +
-                    ' Melding: ' +
-                    response.getBody() +
-                    ')'
-                );
-            } else {
-                throw new AuraHandledException(
-                    'Feil ved henting av brukervarsel \n ' +
-                    'Status: ' +
-                    response.getStatus()
-                );
-            }
-        }
-    }
-
-    @AuraEnabled(cacheable=true)
     public static List<NKS_BrukervarslingBestilling> getBrukerNotifikasjonFromIdent(String fnr) {
         List<NKS_BrukervarslingBestilling> brukernotifikasjoner = new List<NKS_BrukervarslingBestilling>();
 
@@ -55,9 +14,11 @@ public with sharing class NKS_BrukervarselController {
                 brukernotifikasjoner.add(bestilling);
             }
         } catch (Exception e) {
+            LoggerUtility logger = new LoggerUtility();
+            logger.error('Error retrieving brukervarsel \n ' + 'Exception: ' + e, null);
+            logger.publish();
             throw new AuraHandledException('Feil ved henting av brukernotifikasjoner: ' + e.getMessage());
         }
-
         return brukernotifikasjoner;
     }
 }

--- a/force-app/brukervarsel/classes/NKS_BrukervarselControllerTest.cls
+++ b/force-app/brukervarsel/classes/NKS_BrukervarselControllerTest.cls
@@ -1,30 +1,28 @@
 @IsTest
 private with sharing class NKS_BrukervarselControllerTest {
     @IsTest
-    static void importBrukervarselNotificationsSuccess() {
-        ApiMock.setTestMock('GET_VARSEL_FROM_BRUKER_ID', 200, 'OK');
-        List<NKS_BrukervarslingBestilling> result;
+    static void getBrukerNotifikasjonFromIdentTest() {
+        ApiMock.setTestMock('TMS_SERVICE_PATH', 200, 'OK');
+
         Test.startTest();
-        result = NKS_BrukervarselController.getBrukerVarselFromActorId('100003000120', Date.today(), Date.today());
+        List<NKS_BrukervarslingBestilling> brukernotifikasjoner = NKS_BrukerVarselController.getBrukerNotifikasjonFromIdent('10108000398');
         Test.stopTest();
 
-        System.assertEquals(6, result.size(), 'Excpected three items in list');
-    }
+        Assert.isFalse(brukernotifikasjoner.isEmpty());
+    }    
 
     @IsTest
-    static void importBrukervarselNotificationsError() {
-        ApiMock.setTestMock('GET_VARSEL_FROM_BRUKER_ID', 500, 'Error');
+    static void getBrukerNotifikasjonFromIdentExceptionTest() {
+        ApiMock.setTestMock('TMS_SERVICE_PATH', 500, 'Error');
 
         Test.startTest();
         try {
-            NKS_BrukervarselController.getBrukerVarselFromActorId('100003000120', Date.today(), Date.today());
+            List<NKS_BrukervarslingBestilling> brukernotifikasjoner = NKS_BrukerVarselController.getBrukerNotifikasjonFromIdent('10108000398');
         } catch (AuraHandledException ex) {
             System.assert(true, 'Correct exception');
         } catch (Exception ex) {
             System.assert(false, 'Wrong exception');
         }
         Test.stopTest();
-
-        // System.assertEquals(1, [SELECT Id FROM Application_Log__c].size(), 'Excpected an error logged');
-    }
+    }    
 }

--- a/force-app/brukervarsel/lwc/nksBrukervarselList/nksBrukervarselList.js
+++ b/force-app/brukervarsel/lwc/nksBrukervarselList/nksBrukervarselList.js
@@ -1,6 +1,5 @@
 import { LightningElement, api, track, wire } from 'lwc';
 import getRelatedRecord from '@salesforce/apex/NksRecordInfoController.getRelatedRecord';
-import getBrukerVarsel from '@salesforce/apex/NKS_BrukervarselController.getBrukerVarselFromActorId';
 import getBrukernotifikasjon from '@salesforce/apex/NKS_BrukervarselController.getBrukerNotifikasjonFromIdent';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import PERSON_ACTOR_FIELD from '@salesforce/schema/Person__c.INT_ActorId__c';
@@ -21,12 +20,9 @@ export default class NksBrukervarselList extends LightningElement {
     wireFields;
     isLoaded = false;
     wiredPerson = null;
-    varsler = [];
-    brukernotifikasjon = [];
     fromDate;
     toDate;
     wiredBrukerVarsel;
-    usernotificationsLoaded = false;
 
     connectedCallback() {
         this.wireFields = [this.objectApiName + '.Id'];
@@ -35,32 +31,6 @@ export default class NksBrukervarselList extends LightningElement {
 
     get showNotifications() {
         return this.filteredNotificationList.length > 0;
-    }
-
-    filterNotificationList() {
-        let reduceToMaxDate = (c, d) => (c.sendt > d.sendt ? c : d);
-        let getLatestDate = (e) => {
-            return e.sisteVarselutsendelse != null
-                ? e.sisteVarselutsendelse
-                : e.varselListe.reduce(reduceToMaxDate).sendt;
-        };
-
-        /*
-         * sort list descending by date in sisteVarselutsendelse
-         * if missing, then looking for the latest date in varselListe.sendt
-         */
-        let n = [...this.notifications]
-            .filter(
-                (notification) =>
-                    getLatestDate(notification) >= this.fromDate && getLatestDate(notification) <= this.toDate
-            )
-            .sort((a, b) => {
-                let ad = getLatestDate(a);
-                let bd = getLatestDate(b);
-                return (ad < bd) - (ad > bd);
-            });
-
-        this.filteredNotificationList = n;
     }
 
     get maxDate() {
@@ -114,11 +84,8 @@ export default class NksBrukervarselList extends LightningElement {
         this.wiredPerson = value;
 
         if (data) {
-            this.usernotificationsLoaded = false;
-            this.brukernotifikasjon = [];
             this.getNotifications();
         }
-
         if (error) {
             this.addError(error);
         }
@@ -134,7 +101,6 @@ export default class NksBrukervarselList extends LightningElement {
                 this.getRelatedRecordId(this.relationshipField, this.objectApiName);
             }
         }
-
         if (error) {
             this.addError(error);
         }
@@ -143,46 +109,43 @@ export default class NksBrukervarselList extends LightningElement {
     getNotifications() {
         this.isLoaded = false;
         this.errorMessages = [];
-        this.varsler = [];
 
-        const brukervarsler = new Promise((resolve, reject) => {
-            getBrukerVarsel({
-                actorId: this.personActorId,
-                fromDate: this.fromDate,
-                toDate: this.toDate
+        getBrukernotifikasjon({ fnr: this.personIdent })
+            .then((data) => {
+                this.notifications = data;
+                this.filterNotificationList();
+                this.isLoaded = true;
             })
-                .then((data) => {
-                    this.varsler = data;
-                    resolve();
-                })
-                .catch((error) => {
-                    this.addError(error);
-                    reject();
-                });
-        });
+            .catch((error) => {
+                this.addError(error);
+                this.isLoaded = true;
+            });
+    }
 
-        const brukernotifikasjoner = new Promise((resolve, reject) => {
-            if (this.usernotificationsLoaded === true) {
-                resolve();
-            } else {
-                getBrukernotifikasjon({ fnr: this.personIdent })
-                    .then((data) => {
-                        this.brukernotifikasjon = data;
-                        this.usernotificationsLoaded = true;
-                        resolve();
-                    })
-                    .catch((error) => {
-                        this.addError(error);
-                        reject();
-                    });
-            }
-        });
+    filterNotificationList() {
+        let reduceToMaxDate = (c, d) => (c.sendt > d.sendt ? c : d);
+        let getLatestDate = (e) => {
+            return e.sisteVarselutsendelse != null
+                ? e.sisteVarselutsendelse
+                : e.varselListe.reduce(reduceToMaxDate).sendt;
+        };
 
-        Promise.allSettled([brukervarsler, brukernotifikasjoner]).finally(() => {
-            this.notifications = [].concat(this.varsler).concat(this.brukernotifikasjon);
-            this.isLoaded = true;
-            this.filterNotificationList();
-        });
+        /*
+         * sort list descending by date in sisteVarselutsendelse
+         * if missing, then looking for the latest date in varselListe.sendt
+         */
+        let n = [...this.notifications]
+            .filter(
+                (notification) =>
+                    getLatestDate(notification) >= this.fromDate && getLatestDate(notification) <= this.toDate
+            )
+            .sort((a, b) => {
+                let ad = getLatestDate(a);
+                let bd = getLatestDate(b);
+                return (ad < bd) - (ad > bd);
+            });
+
+        this.filteredNotificationList = n;
     }
 
     refreshNotificationList() {


### PR DESCRIPTION
Removed KrakenD and API Gateway integration to Brukervarsel. Brukernotifikasjoner (Team Personbruker) has taken over this solution and Brukervarsel is now dead. Only using Brukernotifikasjoner integration through https://person.nav.no/tms-event-api now. This means proxy and app for Brukervarsel can be shut down.

See: https://github.com/navikt/crm-nks-integration/pull/256