### PR TITLE
Nks audit log improvements

### DIFF
--- a/force-app/main/default/classes/NKS_AuditLogController.cls
+++ b/force-app/main/default/classes/NKS_AuditLogController.cls
@@ -1,10 +1,10 @@
-public without sharing class NKS_AuditLogController {
-    public static final Id USERID = UserInfo.getUserId();
-    public static final String KNOWLEDGE_LOOKUP_FIELD = 'Knowledge__c';
-    public static final String ANNOUNCEMENT_LOOKUP_FIELD = 'Announcement__c';
-    public static final String KNOWLEDGE_AUDIT_LOG = 'Knowledge Audit Log';
-    public static final String ANNOUNCEMENT_AUDIT_LOG = 'Announcement Audit Log';
-
+public with sharing class NKS_AuditLogController {
+    private static final Id USERID = UserInfo.getUserId();
+    private static final String KNOWLEDGE_LOOKUP_FIELD = 'Knowledge__c';
+    private static final String ANNOUNCEMENT_LOOKUP_FIELD = 'Announcement__c';
+    private static final String KNOWLEDGE_AUDIT_LOG = 'Knowledge Audit Log';
+    private static final String ANNOUNCEMENT_AUDIT_LOG = 'Announcement Audit Log';
+    private static final String STATUS_DRAFT = 'Draft';
     private static LoggerUtility logger = new LoggerUtility('NKS Audit Log');
 
     @AuraEnabled
@@ -13,45 +13,45 @@ public without sharing class NKS_AuditLogController {
             return;
         }
 
-        if (lookupField == KNOWLEDGE_LOOKUP_FIELD) { 
+        if (lookupField == KNOWLEDGE_LOOKUP_FIELD) {
             Knowledge__kav kav = [SELECT Id, PublishStatus, KnowledgeArticleId FROM Knowledge__kav WHERE Id = :recordId LIMIT 1];
-            if (kav.PublishStatus != 'Draft') {
+            if (kav.PublishStatus!= STATUS_DRAFT) {
                 createAuditLogRecord(recordId, KNOWLEDGE_AUDIT_LOG, kav.KnowledgeArticleId);
             }
         } 
         else if (lookupField == ANNOUNCEMENT_LOOKUP_FIELD) {
             NKS_Announcement__c announcement = [SELECT Id, NKS_News_Status__c FROM NKS_Announcement__c WHERE Id = :recordId LIMIT 1];
-            if (announcement.NKS_News_Status__c != 'Draft') {
+            if (announcement.NKS_News_Status__c!= STATUS_DRAFT) {
                 createAuditLogRecord(recordId, ANNOUNCEMENT_AUDIT_LOG, null);
             }
         }
-}
-
-private static void createAuditLogRecord(Id recordId, String lookupField, String knowledgeArticleId) {
-    try {
-        NKS_Audit_Log__c auditLog = new NKS_Audit_Log__c();
-        auditLog.RecordTypeId = getRecordTypeId(lookupField);
-        auditLog.User__c = USERID;  
-        auditLog.Operation__c = 'View';
-        if (lookupField == KNOWLEDGE_AUDIT_LOG) {
-            auditLog.Knowledge__c = recordId;
-            auditLog.Knowledge_Id__c = recordId;
-            auditLog.Knowledge_Article_Id__c = knowledgeArticleId;
-        } else if (lookupField == ANNOUNCEMENT_AUDIT_LOG) {
-            auditLog.Announcement__c = recordId;
-            auditLog.Announcement_Id__c = recordId;
-        }
-
-        Database.SaveResult sr = Database.insert(auditLog, false);
-        if (!sr.isSuccess()) {
-            logErrorMessage(sr);
-        }
-    } catch (Exception e) {
-        logger.error('Failed to create Audit Log record: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
-    } finally {
-        logger.publish();
     }
-}
+
+    private static void createAuditLogRecord(Id recordId, String lookupField, String knowledgeArticleId) {
+        try {
+            NKS_Audit_Log__c auditLog = new NKS_Audit_Log__c();
+            auditLog.RecordTypeId = getRecordTypeId(lookupField);
+            auditLog.User__c = USERID;  
+            auditLog.Operation__c = 'View';
+            if (lookupField == KNOWLEDGE_AUDIT_LOG) {
+                auditLog.Knowledge__c = recordId;
+                auditLog.Knowledge_Id__c = recordId;
+                auditLog.Knowledge_Article_Id__c = knowledgeArticleId;
+            } else if (lookupField == ANNOUNCEMENT_AUDIT_LOG) {
+                auditLog.Announcement__c = recordId;
+                auditLog.Announcement_Id__c = recordId;
+            }
+
+            Database.SaveResult sr = Database.insert(auditLog, false);
+            if (!sr.isSuccess()) {
+                logErrorMessage(sr);
+            }
+        } catch (Exception e) {
+            logger.error('Failed to create Audit Log record: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
+        } finally {
+            logger.publish();
+        }
+    }
 
     @AuraEnabled(cacheable=true)
     public static Integer countViews(Id recordId, String lookupField) {
@@ -59,9 +59,9 @@ private static void createAuditLogRecord(Id recordId, String lookupField, String
         Set<Id> resultList = new Set<Id>();
         Map<String, Object> bindParams = new Map<String, Object>{ 'recordId' => recordId };
         String query =
-            'SELECT COUNT_DISTINCT(User__c) nmbOfUniqueViews FROM NKS_Audit_Log__c WHERE ' +
-            lookupField +
-            ' = :recordId';
+        'SELECT COUNT_DISTINCT(User__c) nmbOfUniqueViews FROM NKS_Audit_Log__c WHERE ' +
+        lookupField +
+        ' = :recordId';
         try {
             AggregateResult[] countResult = Database.queryWithBinds(query, bindParams, AccessLevel.SYSTEM_MODE);
             return Integer.valueOf(countResult[0].get('nmbOfUniqueViews'));

--- a/force-app/main/default/classes/NKS_AuditLogController.cls
+++ b/force-app/main/default/classes/NKS_AuditLogController.cls
@@ -14,14 +14,23 @@ public with sharing class NKS_AuditLogController {
         }
 
         if (lookupField == KNOWLEDGE_LOOKUP_FIELD) {
-            Knowledge__kav kav = [SELECT Id, PublishStatus, KnowledgeArticleId FROM Knowledge__kav WHERE Id = :recordId LIMIT 1];
-            if (kav.PublishStatus!= STATUS_DRAFT) {
+            Knowledge__kav kav = [
+                SELECT Id, PublishStatus, KnowledgeArticleId
+                FROM Knowledge__kav
+                WHERE Id = :recordId
+                LIMIT 1
+            ];
+            if (kav.PublishStatus != STATUS_DRAFT) {
                 createAuditLogRecord(recordId, KNOWLEDGE_AUDIT_LOG, kav.KnowledgeArticleId);
             }
-        } 
-        else if (lookupField == ANNOUNCEMENT_LOOKUP_FIELD) {
-            NKS_Announcement__c announcement = [SELECT Id, NKS_News_Status__c FROM NKS_Announcement__c WHERE Id = :recordId LIMIT 1];
-            if (announcement.NKS_News_Status__c!= STATUS_DRAFT) {
+        } else if (lookupField == ANNOUNCEMENT_LOOKUP_FIELD) {
+            NKS_Announcement__c announcement = [
+                SELECT Id, NKS_News_Status__c
+                FROM NKS_Announcement__c
+                WHERE Id = :recordId
+                LIMIT 1
+            ];
+            if (announcement.NKS_News_Status__c != STATUS_DRAFT) {
                 createAuditLogRecord(recordId, ANNOUNCEMENT_AUDIT_LOG, null);
             }
         }
@@ -31,8 +40,9 @@ public with sharing class NKS_AuditLogController {
         try {
             NKS_Audit_Log__c auditLog = new NKS_Audit_Log__c();
             auditLog.RecordTypeId = getRecordTypeId(lookupField);
-            auditLog.User__c = USERID;  
+            auditLog.User__c = USERID;
             auditLog.Operation__c = 'View';
+
             if (lookupField == KNOWLEDGE_AUDIT_LOG) {
                 auditLog.Knowledge__c = recordId;
                 auditLog.Knowledge_Id__c = recordId;
@@ -47,7 +57,11 @@ public with sharing class NKS_AuditLogController {
                 logErrorMessage(sr);
             }
         } catch (Exception e) {
-            logger.error('Failed to create Audit Log record: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
+            logger.error(
+                'Failed to create Audit Log record: ' + e.getMessage(),
+                null,
+                CRM_ApplicationDomain.Domain.NKS
+            );
         } finally {
             logger.publish();
         }
@@ -59,9 +73,10 @@ public with sharing class NKS_AuditLogController {
         Set<Id> resultList = new Set<Id>();
         Map<String, Object> bindParams = new Map<String, Object>{ 'recordId' => recordId };
         String query =
-        'SELECT COUNT_DISTINCT(User__c) nmbOfUniqueViews FROM NKS_Audit_Log__c WHERE ' +
-        lookupField +
-        ' = :recordId';
+            'SELECT COUNT_DISTINCT(User__c) nmbOfUniqueViews FROM NKS_Audit_Log__c WHERE ' +
+            lookupField +
+            ' = :recordId';
+
         try {
             AggregateResult[] countResult = Database.queryWithBinds(query, bindParams, AccessLevel.SYSTEM_MODE);
             return Integer.valueOf(countResult[0].get('nmbOfUniqueViews'));
@@ -78,15 +93,15 @@ public with sharing class NKS_AuditLogController {
             throw new AuraHandledException('Problem checking knowledge user: ' + e.getMessage());
         }
     }
- 
+
     @TestVisible
     private static String getRecordTypeId(String recordTypeName) {
         return Schema.SObjectType.NKS_Audit_Log__c.getRecordTypeInfosByName().get(recordTypeName).getRecordTypeId();
     }
 
-    private static void logErrorMessage (Database.SaveResult sr) {
+    private static void logErrorMessage(Database.SaveResult sr) {
         String errorMessage = 'The following error has occurred under creation of Audit Log record:\n';
-        for(Database.Error error : sr.getErrors()) {
+        for (Database.Error error : sr.getErrors()) {
             errorMessage += error.getStatusCode() + ': ' + error.getMessage() + '\n';
         }
         logger.error(errorMessage, null, CRM_ApplicationDomain.Domain.NKS);

--- a/force-app/main/default/classes/NKS_AuditLogController.cls
+++ b/force-app/main/default/classes/NKS_AuditLogController.cls
@@ -9,33 +9,49 @@ public without sharing class NKS_AuditLogController {
 
     @AuraEnabled
     public static void createAuditLog(Id recordId, String lookupField) {
-        try {
-            NKS_Audit_Log__c al = new NKS_Audit_Log__c();
-            if (lookupField == KNOWLEDGE_LOOKUP_FIELD) {
-                al.RecordTypeId = getRecordTypeId(KNOWLEDGE_AUDIT_LOG);
-                al.Knowledge__c = recordId;
+        if (recordId == null || lookupField == null) {
+            return;
+        }
+
+        if (lookupField == KNOWLEDGE_LOOKUP_FIELD) { 
+            Knowledge__kav kav = [SELECT Id, PublishStatus, KnowledgeArticleId FROM Knowledge__kav WHERE Id = :recordId LIMIT 1];
+            if (kav.PublishStatus != 'Draft') {
+                createAuditLogRecord(recordId, KNOWLEDGE_AUDIT_LOG, kav.KnowledgeArticleId);
             }
-            else if (lookupField == ANNOUNCEMENT_LOOKUP_FIELD) {
-                al.RecordTypeId = getRecordTypeId(ANNOUNCEMENT_AUDIT_LOG);
-                al.Announcement__c = recordId;
+        } 
+        else if (lookupField == ANNOUNCEMENT_LOOKUP_FIELD) {
+            NKS_Announcement__c announcement = [SELECT Id, NKS_News_Status__c FROM NKS_Announcement__c WHERE Id = :recordId LIMIT 1];
+            if (announcement.NKS_News_Status__c != 'Draft') {
+                createAuditLogRecord(recordId, ANNOUNCEMENT_AUDIT_LOG, null);
             }
-            else {
-                return;
-            }
-              
-            al.User__c = USERID;
-            al.Operation__c = 'View';
-            
-            Database.SaveResult sr = Database.insert(al, false);
-            if (!sr.isSuccess()) {
-                logErrorMessage (sr);
-            }
-        } catch (Exception e) {
-            logger.error('Failed to create Audit Log record: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
+        }
+}
+
+private static void createAuditLogRecord(Id recordId, String lookupField, String knowledgeArticleId) {
+    try {
+        NKS_Audit_Log__c auditLog = new NKS_Audit_Log__c();
+        auditLog.RecordTypeId = getRecordTypeId(lookupField);
+        auditLog.User__c = USERID;  
+        auditLog.Operation__c = 'View';
+        if (lookupField == KNOWLEDGE_AUDIT_LOG) {
+            auditLog.Knowledge__c = recordId;
+            auditLog.Knowledge_Id__c = recordId;
+            auditLog.Knowledge_Article_Id__c = knowledgeArticleId;
+        } else if (lookupField == ANNOUNCEMENT_AUDIT_LOG) {
+            auditLog.Announcement__c = recordId;
+            auditLog.Announcement_Id__c = recordId;
+        }
+
+        Database.SaveResult sr = Database.insert(auditLog, false);
+        if (!sr.isSuccess()) {
+            logErrorMessage(sr);
+        }
+    } catch (Exception e) {
+        logger.error('Failed to create Audit Log record: ' + e.getMessage(), null, CRM_ApplicationDomain.Domain.NKS);
     } finally {
         logger.publish();
-    } 
     }
+}
 
     @AuraEnabled(cacheable=true)
     public static Integer countViews(Id recordId, String lookupField) {

--- a/force-app/main/default/classes/NKS_AuditLogControllerTest.cls
+++ b/force-app/main/default/classes/NKS_AuditLogControllerTest.cls
@@ -3,6 +3,7 @@ public with sharing class NKS_AuditLogControllerTest {
     @TestSetup
     static void makeData() {
         NKS_Announcement__c news = new NKS_Announcement__c();
+        news.NKS_News_Status__c = 'Published';
         insert news;
 
         Knowledge__kav article = new Knowledge__kav();
@@ -10,21 +11,26 @@ public with sharing class NKS_AuditLogControllerTest {
         article.UrlName = 'Test-Article';
         insert article;
 
+        Knowledge__kav kav = [SELECT id, KnowledgeArticleId FROM Knowledge__kav WHERE id = :article.Id LIMIT 1];
+        KbManagement.PublishingService.publishArticle(kav.KnowledgeArticleId, true);
+
         Id rtId = NKS_AuditLogController.getRecordTypeId('Knowledge Audit Log');
         NKS_Audit_Log__c al = new NKS_Audit_Log__c();
         al.User__c = UserInfo.getUserId();
         al.RecordTypeId = rtId;
         al.Knowledge__c = article.Id;
+        al.Knowledge_Article_Id__c = article.KnowledgeArticleId;
+        al.Operation__c = 'View';
         insert al;
     }
 
     @isTest
     static void testCreateAuditLog() {
-        Id articleId = [SELECT Id FROM Knowledge__kav LIMIT 1]?.Id;
+        Knowledge__kav kav = [SELECT Id FROM Knowledge__kav LIMIT 1];
         Id newsId = [SELECT Id FROM NKS_Announcement__c LIMIT 1]?.Id;
 
         Test.startTest();
-        NKS_AuditLogController.createAuditLog(articleId, 'Knowledge__c');
+        NKS_AuditLogController.createAuditLog(kav.id, 'Knowledge__c');
         NKS_AuditLogController.createAuditLog(newsId, 'Announcement__c');
         Test.stopTest();
     }

--- a/force-app/main/default/classes/NKS_AuditLogControllerTest.cls
+++ b/force-app/main/default/classes/NKS_AuditLogControllerTest.cls
@@ -26,11 +26,11 @@ public with sharing class NKS_AuditLogControllerTest {
 
     @isTest
     static void testCreateAuditLog() {
-        Knowledge__kav kav = [SELECT Id FROM Knowledge__kav LIMIT 1];
+        Id articleId = [SELECT Id FROM Knowledge__kav LIMIT 1]?.Id;
         Id newsId = [SELECT Id FROM NKS_Announcement__c LIMIT 1]?.Id;
 
         Test.startTest();
-        NKS_AuditLogController.createAuditLog(kav.id, 'Knowledge__c');
+        NKS_AuditLogController.createAuditLog(articleId, 'Knowledge__c');
         NKS_AuditLogController.createAuditLog(newsId, 'Announcement__c');
         Test.stopTest();
     }

--- a/force-app/main/default/layouts/NKS_Audit_Log__c-Announcement Audit Log Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/NKS_Audit_Log__c-Announcement Audit Log Layout.layout-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
+    <excludeButtons>OpenSlackRecordChannel</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
@@ -11,15 +12,19 @@
                 <field>Name</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>Announcement__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
+                <field>Announcement_Id__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>Operation__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>User__c</field>
             </layoutItems>
             <layoutItems>
@@ -27,7 +32,7 @@
                 <field>Viewed_date__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
+        <layoutColumns />
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -54,9 +59,9 @@
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>Custom Links</label>
-        <layoutColumns/>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <showEmailCheckbox>false</showEmailCheckbox>
@@ -65,7 +70,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1l000001AW84</masterLabel>
+        <masterLabel>00hKO000000jrho</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/NKS_Audit_Log__c-Knowledge Audit Log Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/NKS_Audit_Log__c-Knowledge Audit Log Layout.layout-meta.xml
@@ -11,15 +11,23 @@
                 <field>Name</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>Knowledge__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
+                <field>Knowledge_Id__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>Knowledge_Article_Id__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>Operation__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>User__c</field>
             </layoutItems>
             <layoutItems>
@@ -27,7 +35,7 @@
                 <field>Viewed_date__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
+        <layoutColumns />
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -54,9 +62,9 @@
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>Custom Links</label>
-        <layoutColumns/>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <showEmailCheckbox>false</showEmailCheckbox>
@@ -65,7 +73,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1l000001AXYC</masterLabel>
+        <masterLabel>00hKO000000jrhz</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/NKS_Audit_Log__c/fields/Announcement_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/NKS_Audit_Log__c/fields/Announcement_Id__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Announcement_Id__c</fullName>
+    <externalId>false</externalId>
+    <label>Announcement Id</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NKS_Audit_Log__c/fields/Knowledge_Article_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/NKS_Audit_Log__c/fields/Knowledge_Article_Id__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Knowledge_Article_Id__c</fullName>
+    <externalId>false</externalId>
+    <label>Knowledge Article Id</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/NKS_Audit_Log__c/fields/Knowledge_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/NKS_Audit_Log__c/fields/Knowledge_Id__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Knowledge_Id__c</fullName>
+    <externalId>false</externalId>
+    <label>Knowledge Id</label>
+    <length>18</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/NKS_Config.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Config.permissionset-meta.xml
@@ -237,7 +237,22 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>NKS_Audit_Log__c.Announcement_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>NKS_Audit_Log__c.Announcement__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>NKS_Audit_Log__c.Knowledge_Article_Id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>NKS_Audit_Log__c.Knowledge_Id__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -431,10 +446,6 @@
         <tab>standard-OmniSupervisorLightning</tab>
         <visibility>Visible</visibility>
     </tabSettings>
-    <tabSettings>
-        <tab>standard-Workspace</tab>
-        <visibility>Visible</visibility>
-    </tabSettings>
     <userPermissions>
         <enabled>true</enabled>
         <name>AccessCMC</name>
@@ -494,10 +505,6 @@
     <userPermissions>
         <enabled>true</enabled>
         <name>EditPublicFilters</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>EinsteinArticleRecUser</name>
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>

--- a/force-app/main/default/permissionsets/NKS_Config.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/NKS_Config.permissionset-meta.xml
@@ -446,6 +446,10 @@
         <tab>standard-OmniSupervisorLightning</tab>
         <visibility>Visible</visibility>
     </tabSettings>
+    <tabSettings>
+        <tab>standard-Workspace</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
     <userPermissions>
         <enabled>true</enabled>
         <name>AccessCMC</name>
@@ -505,6 +509,10 @@
     <userPermissions>
         <enabled>true</enabled>
         <name>EditPublicFilters</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>EinsteinArticleRecUser</name>
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
             "default": true,
             "package": "crm-nks-base",
             "versionName": "ver 0.1",
-            "versionNumber": "0.365.0.NEXT",
+            "versionNumber": "0.366.0.NEXT",
             "dependencies": [
                 {
                     "package": "crm-platform-base",


### PR DESCRIPTION
Forbedringer gjelder: 
- Audit log records med tomt lookup felt: referansen til disse blir tydeligvis slettet når record blir slettet (det kan være andre grunner også, som ikke oppdaget så langt, men kan finne ut av når recordid blir lagret som tekst da finnes mulighet for å finne ut record-en igjen og se hva som har endret seg på den).
- Ikke opprette log hvis artikkelen er av typen utkast 