### PR TITLE
refactored callflowcontroller

### DIFF
--- a/force-app/main/default/classes/NKS_CallFlowController.cls
+++ b/force-app/main/default/classes/NKS_CallFlowController.cls
@@ -87,13 +87,9 @@ public without sharing class NKS_CallFlowController {
             }
 
             String queue = (String) log.get('puzzel__Queue__c');
-            if (queue == null) {
-                queue = '';
-            }
+            queue = String.isBlank(queue) ? '' : queue;
             String accessNumber = (String) log.get('puzzel__AccessNumber__c');
-            if (accessNumber == null) {
-                accessNumber = '';
-            }
+            accessNumber = String.isBlank(accessNumber) ? '' : accessNumber;
 
             Puzzel_Queue_Mapping__mdt queueMapping = contextMap.get(queue?.toLowerCase());
             if (queueMapping == null) {

--- a/force-app/main/default/classes/NKS_CallFlowController.cls
+++ b/force-app/main/default/classes/NKS_CallFlowController.cls
@@ -87,7 +87,13 @@ public without sharing class NKS_CallFlowController {
             }
 
             String queue = (String) log.get('puzzel__Queue__c');
+            if (queue == null) {
+                queue = '';
+            }
             String accessNumber = (String) log.get('puzzel__AccessNumber__c');
+            if (accessNumber == null) {
+                accessNumber = '';
+            }
 
             Puzzel_Queue_Mapping__mdt queueMapping = contextMap.get(queue?.toLowerCase());
             if (queueMapping == null) {
@@ -110,7 +116,6 @@ public without sharing class NKS_CallFlowController {
         return responses;
     }
 
-    // --- RESPONSE CLASS ---
     public class CallQueueResponse {
         @InvocableVariable
         public String themeGroup;

--- a/force-app/main/default/classes/NKS_CallFlowController.cls
+++ b/force-app/main/default/classes/NKS_CallFlowController.cls
@@ -1,18 +1,34 @@
 public without sharing class NKS_CallFlowController {
-    private static final List<String> QueryFields = new List<String>{
+    private static final List<String> QUERY_FIELDS = new List<String>{
         'puzzel__SessionId__c',
         'puzzel__Queue__c',
         'puzzel__AccessNumber__c'
     };
-    private static Map<String, Schema.SObjectType> globalDesc = Schema.getGlobalDescribe();
+    private static final String DEFAULT_CONTEXT = 'PERSON';
+    private static final String DEFAULT_QUEUE = 'TEST QUEUE';
+    private static final Map<String, Schema.SObjectType> GLOBAL_DESC = Schema.getGlobalDescribe();
 
-    /**
-     * @description: Returns the Enquiry log SObject type if it exists
-     * @author Stian Ruud Schikora | 05-28-2021
-     * @return Schema.SObjectType
-     **/
     private static Schema.SObjectType getEnquiryLogObject() {
-        return globalDesc.containsKey('puzzel__EnquiryLog__c') ? globalDesc.get('puzzel__EnquiryLog__c') : null;
+        return GLOBAL_DESC.get('puzzel__EnquiryLog__c');
+    }
+
+    private static List<Puzzel_Queue_Mapping__mdt> getQueueMappings(Set<String> queueNames) {
+        return [
+            SELECT Puzzel_Queue_Name__c, Theme_Group_Code__c, Caller_Context__c
+            FROM Puzzel_Queue_Mapping__mdt
+            WHERE Puzzel_Queue_Name__c IN :queueNames
+        ];
+    }
+
+    private static List<SObject> getEnquiryLogs(List<String> sessionIds) {
+        if (Test.isRunningTest()) {
+            return (List<SObject>) JSON.deserialize(NKS_CallFlowController_Test.MOCK_ENQUIRY_LOG, SObject[].class);
+        }
+
+        fflib_QueryFactory qf = new fflib_QueryFactory(getEnquiryLogObject());
+        return Database.query(
+            qf.selectFields(QUERY_FIELDS).setCondition('puzzel__SessionId__c IN :sessionIds').toSOQL()
+        );
     }
 
     @InvocableMethod(
@@ -22,131 +38,102 @@ public without sharing class NKS_CallFlowController {
     )
     public static List<CallQueueResponse> getCallQueueInfo(List<String> sessionIds) {
         LoggerUtility logger = new LoggerUtility('CallFlowController');
-        List<CallQueueResponse> respList = new List<CallQueueResponse>();
+        List<CallQueueResponse> responses = new List<CallQueueResponse>();
 
         if (getEnquiryLogObject() == null && !Test.isRunningTest()) {
-            for (String puzSessionId : sessionIds) {
-                logger.error('Could not find Enquiry Log schema', null, CRM_ApplicationDomain.Domain.NKS);
-                respList.add(new CallQueueResponse(null, '')); //Person is fallback when there is no match
+            for (String puzzelSessionId : sessionIds) {
+                logger.error('Missing Enquiry Log object', null, CRM_ApplicationDomain.Domain.NKS);
+                responses.add(new CallQueueResponse(null, ''));
             }
-        } else {
-            List<Object> enqLogs = getEnquiryLogs(sessionIds);
-            Map<String, Object> enqLogsMap = new Map<String, Object>();
-            Set<String> queueNames = new Set<String>();
-            for (Object enqLog : enqLogs) {
-                Map<String, Object> enqMap = (Map<String, Object>) enqLog;
-                if (enqMap.containsKey('puzzel__SessionId__c'))
-                    enqLogsmap.put((String) enqMap.get('puzzel__SessionId__c'), enqLog);
-                if (enqMap.containsKey('puzzel__Queue__c'))
-                    queueNames.add((String) enqMap.get('puzzel__Queue__c'));
-            }
-
-            Map<String, Puzzel_Queue_Mapping__mdt> contextMap = new Map<String, Puzzel_Queue_Mapping__mdt>();
-            for (Puzzel_Queue_Mapping__mdt queueMapping : getQueueMappings(queueNames)) {
-                contextMap.put(queueMapping.Puzzel_Queue_Name__c.toLowerCase(), queueMapping);
-            }
-
-            for (String sessionId : sessionIds) {
-                Object enqLog = enqLogsMap.get(sessionId);
-                if (enqLog == null) {
-                    logger.warning(
-                        'Could not find enquiry log for sessionId ' +
-                            sessionId +
-                            ' with queue map ' +
-                            JSON.serialize(enqLogsMap) +
-                            ' with and logs ' +
-                            JSON.serialize(enqLogs),
-                        null,
-                        CRM_ApplicationDomain.Domain.NKS
-                    );
-                    respList.add(new CallQueueResponse());
-                    continue;
-                }
-                Map<String, Object> enqMap = (Map<String, Object>) enqLog;
-                String queue = enqMap.containsKey('puzzel__Queue__c') ? (String) enqMap.get('puzzel__Queue__c') : '';
-                String accessNumber = enqMap.containsKey('puzzel__AccessNumber__c')
-                    ? (String) enqMap.get('puzzel__AccessNumber__c')
-                    : '';
-                Puzzel_Queue_Mapping__mdt queueMapping = contextMap.get(queue.toLowerCase());
-                if (queueMapping == null) {
-                    logger.error(
-                        'Could not find queue mapping for sessionId ' +
-                            sessionId +
-                            ' with queue name ' +
-                            queue +
-                            ' and map ' +
-                            JSON.serialize(contextMap),
-                        null,
-                        CRM_ApplicationDomain.Domain.NKS
-                    );
-                }
-                respList.add(new CallQueueResponse(queueMapping, accessNumber));
-            }
+            logger.publish();
+            return responses;
         }
+
+        List<SObject> enqLogs = getEnquiryLogs(sessionIds);
+        Map<String, SObject> enqLogsBySession = new Map<String, SObject>();
+        Set<String> queueNames = new Set<String>();
+
+        for (SObject log : enqLogs) {
+            String sessionId = (String) log.get('puzzel__SessionId__c');
+            if (sessionId != null)
+                enqLogsBySession.put(sessionId, log);
+
+            String queue = (String) log.get('puzzel__Queue__c');
+            if (queue != null)
+                queueNames.add(queue);
+        }
+
+        Map<String, Puzzel_Queue_Mapping__mdt> contextMap = new Map<String, Puzzel_Queue_Mapping__mdt>();
+        for (Puzzel_Queue_Mapping__mdt queueMapping : getQueueMappings(queueNames)) {
+            contextMap.put(queueMapping.Puzzel_Queue_Name__c.toLowerCase(), queueMapping);
+        }
+
+        for (String sessionId : sessionIds) {
+            SObject log = enqLogsBySession.get(sessionId);
+
+            if (log == null) {
+                logger.warning(
+                    'No enquiry log for sessionId ' +
+                        sessionId +
+                        ' with queue map ' +
+                        JSON.serialize(enqLogsBySession) +
+                        ' and logs ' +
+                        JSON.serialize(enqLogs),
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+                responses.add(new CallQueueResponse());
+                continue;
+            }
+
+            String queue = (String) log.get('puzzel__Queue__c');
+            String accessNumber = (String) log.get('puzzel__AccessNumber__c');
+
+            Puzzel_Queue_Mapping__mdt queueMapping = contextMap.get(queue?.toLowerCase());
+            if (queueMapping == null) {
+                logger.error(
+                    'Could not find queue mapping for sessionId ' +
+                        sessionId +
+                        ' with queue name ' +
+                        queue +
+                        ' and map ' +
+                        JSON.serialize(contextMap),
+                    null,
+                    CRM_ApplicationDomain.Domain.NKS
+                );
+            }
+
+            responses.add(new CallQueueResponse(queueMapping, accessNumber));
+        }
+
         logger.publish();
-        return respList;
+        return responses;
     }
 
-    /**
-     * @description: Returns the mappings from custom metadata for the defines queue names
-     * @author Stian Ruud Schikora | 05-28-2021
-     * @param queueNames
-     * @return List<Puzzel_Queue_Mapping__mdt>
-     **/
-    private static List<Puzzel_Queue_Mapping__mdt> getQueueMappings(Set<String> queueNames) {
-        return [
-            SELECT Puzzel_Queue_Name__c, Theme_Group_Code__c, Caller_Context__c
-            FROM Puzzel_Queue_Mapping__mdt
-            WHERE Puzzel_Queue_Name__c IN :queueNames
-        ];
-    }
-
-    /**
-     * @description: Queries the enquiry logs matching the sessionId set.
-     * @author Stian Ruud Schikora | 05-28-2021
-     * @param sessionIds
-     * @return List<SObject>
-     **/
-    private static List<Object> getEnquiryLogs(List<String> sessionIds) {
-        fflib_QueryFactory queryFactory = new fflib_QueryFactory(getEnquiryLogObject());
-
-        return Test.isRunningTest()
-            ? (List<Object>) JSON.deserializeUntyped(NKS_CallFlowController_Test.MOCK_ENQUIRY_LOG)
-            : (List<Object>) JSON.deserializeUntyped(
-                  JSON.serialize(
-                      Database.query(
-                          queryFactory.selectFields(QueryFields)
-                              .setCondition('puzzel__SessionId__c in :sessionIds')
-                              .toSOQL()
-                      )
-                  )
-              );
-    }
-
+    // --- RESPONSE CLASS ---
     public class CallQueueResponse {
-        @invocableVariable
+        @InvocableVariable
         public String themeGroup;
-        @invocableVariable
+        @InvocableVariable
         public String callerContext;
-        @invocableVariable
+        @InvocableVariable
         public String queueName;
-        @invocableVariable
+        @InvocableVariable
         public String accessNumber;
 
         public CallQueueResponse() {
         }
-
         public CallQueueResponse(Puzzel_Queue_Mapping__mdt mapping, String accessNumber) {
+            this.accessNumber = accessNumber;
             if (mapping != null) {
                 this.themeGroup = mapping.Theme_Group_Code__c;
                 this.callerContext = mapping.Caller_Context__c;
                 this.queueName = mapping.Puzzel_Queue_Name__c;
             } else {
                 this.themeGroup = '';
-                this.callerContext = 'PERSON';
-                this.queueName = 'TEST QUEUE';
+                this.callerContext = DEFAULT_CONTEXT;
+                this.queueName = DEFAULT_QUEUE;
             }
-            this.accessNumber = accessNumber;
         }
     }
 }

--- a/force-app/main/default/classes/NKS_CallFlowController_Test.cls
+++ b/force-app/main/default/classes/NKS_CallFlowController_Test.cls
@@ -5,11 +5,14 @@ public class NKS_CallFlowController_Test {
     public static final String TEST_ACCESSNUMBER = '12345678';
 
     public static String MOCK_ENQUIRY_LOG =
-        '[{"puzzel__SessionId__c":"' +
+        '[{"attributes":{"type":"puzzel__EnquiryLog__c"},' +
+        '"puzzel__SessionId__c":"' +
         TEST_SESSION_ID +
-        '", "puzzel__Queue__c": "' +
+        '",' +
+        '"puzzel__Queue__c":"' +
         TEST_QUEUE +
-        '", "puzzel__AccessNumber__c": "' +
+        '",' +
+        '"puzzel__AccessNumber__c":"' +
         TEST_ACCESSNUMBER +
         '"}]';
 

--- a/force-app/main/default/classes/NKS_CallLogBatch_Test.cls
+++ b/force-app/main/default/classes/NKS_CallLogBatch_Test.cls
@@ -210,20 +210,22 @@ public with sharing class NKS_CallLogBatch_Test {
         Id callLogId = callLog.Id;
         Id cNoteId = cNote.Id;
 
-        List<Object> originalList = (List<Object>) JSON.deserializeUntyped(
-            NKS_CallFlowController_Test.MOCK_ENQUIRY_LOG
+        List<SObject> originalList = (List<SObject>) JSON.deserialize(
+            NKS_CallFlowController_Test.MOCK_ENQUIRY_LOG,
+            SObject[].class
         );
-        originalList.add(
-            (Object) JSON.deserializeUntyped(
-                '{"puzzel__SessionId__c":"' +
-                    testSessionId +
-                    '", "puzzel__Queue__c": "' +
-                    testQueueName +
-                    '", "puzzel__AccessNumber__c": "' +
-                    testAccessNumber +
-                    '"}'
-            )
-        );
+        String newEntry =
+            '{"attributes":{"type":"puzzel__EnquiryLog__c"},' +
+            '"puzzel__SessionId__c":"' +
+            testSessionId +
+            '",' +
+            '"puzzel__Queue__c":"' +
+            testQueueName +
+            '",' +
+            '"puzzel__AccessNumber__c":"' +
+            testAccessNumber +
+            '"}';
+        originalList.addAll((List<SObject>) JSON.deserialize('[' + newEntry + ']', SObject[].class));
         NKS_CallFlowController_Test.MOCK_ENQUIRY_LOG = JSON.serialize(originalList);
         NKS_CallLogBatch batch = new NKS_CallLogBatch();
 


### PR DESCRIPTION
Av en eller annen grunn ble Database.query resultatet som returnerer typen SObject serialized til en JSON for så å bli deserialized til type Object som bare gjorde hele klassen tunglest. Bruker nå SObject direkte istedenfor.

Testet OK i SIT2 med nyeste Puzzel-pakke.