### PR TITLE
TOLK-3134: Sharing Event for HOT_BRUKER-TOLK threads

### DIFF
--- a/force-app/access-control/thread/classes/NKS_ThreadAccessHandler.cls
+++ b/force-app/access-control/thread/classes/NKS_ThreadAccessHandler.cls
@@ -1,5 +1,6 @@
 global class NKS_ThreadAccessHandler extends MyTriggers {
     private static final List<String> THREAD_TYPES_OF_INTEREST = new List<String>{ 'STO', 'STB', 'BTO', 'CHAT' };
+    private static final Set<String> TOLK_THREAD_TYPES = new Set<String>{ 'HOT_BRUKER-TOLK' };
 
     global override void onAfterUpdate(Map<Id, sObject> triggerOldMap) {
         List<String> fieldNamesToCheck = new List<String>{
@@ -42,7 +43,10 @@ global class NKS_ThreadAccessHandler extends MyTriggers {
         //run sharing in a platform event
 
         for (Thread__c thread : (List<Thread__c>) records) {
-            if (THREAD_TYPES_OF_INTEREST.contains(thread.CRM_Thread_Type__c)) {
+            if (
+                THREAD_TYPES_OF_INTEREST.contains(thread.CRM_Thread_Type__c) ||
+                TOLK_THREAD_TYPES.contains(thread.CRM_Thread_Type__c) // fire event for TOLK threads as well
+            ) {
                 RecordSharingEvent__e event = new RecordSharingEvent__e();
                 event.RecordId__c = thread.Id;
                 event.ObjectType__c = 'Thread__c';

--- a/force-app/access-control/thread/classes/NKS_ThreadSharingEventHandler.cls
+++ b/force-app/access-control/thread/classes/NKS_ThreadSharingEventHandler.cls
@@ -1,4 +1,6 @@
 public without sharing class NKS_ThreadSharingEventHandler extends RecordSharingEvent {
+    private static final List<String> THREAD_TYPES_OF_INTEREST = new List<String>{ 'STO', 'STB', 'BTO', 'CHAT' };
+    private static final Set<String> TOLK_THREAD_TYPES = new Set<String>{ 'HOT_BRUKER-TOLK' };
     private static LoggerUtility logger = new LoggerUtility('STO');
     List<Id> recordIds = new List<Id>();
 
@@ -11,22 +13,23 @@ public without sharing class NKS_ThreadSharingEventHandler extends RecordSharing
                 recordIds.add(sharingEvent.RecordId__c);
             }
 
-            List<Thread__c> threads = [
-                SELECT
-                    Id,
-                    CRM_Account__c,
-                    CRM_Henvendelse_BehandlingsId__c,
-                    CRM_Office_Restriction__c,
-                    CRM_Theme_Code__c,
-                    CRM_Theme_Group_Name__c,
-                    STO_Category__c,
-                    CRM_Theme__c,
-                    CRM_Thread_Type__c
-                FROM Thread__c
-                WHERE Id IN :recordIds
-            ];
-            if (threads.size() > 0) {
-                new NKS_ThreadAccessHandler().grantAccessToNewThreads(threads);
+            List<Thread__c> threads = getThreadsByIds(recordIds);
+            List<Thread__c> nksThreads = new List<Thread__c>();
+            List<Thread__c> tolkThreads = new List<Thread__c>();
+            for (Thread__c thread : threads) {
+                if (THREAD_TYPES_OF_INTEREST.contains(thread.CRM_Thread_Type__c)) {
+                    nksThreads.add(thread);
+                } else if (TOLK_THREAD_TYPES.contains(thread.CRM_Thread_Type__c)) {
+                    tolkThreads.add(thread);
+                }
+            }
+            if (nksThreads.size() > 0 || tolkThreads.size() > 0) {
+                if (nksThreads.size() > 0) {
+                    new NKS_ThreadAccessHandler().grantAccessToNewThreads(threads);
+                }
+                if (tolkThreads.size() > 0) {
+                    this.processTolkThreads(tolkThreads);
+                }
             } else {
                 logger.critical(
                     'Recieved Record Sharing event but found no Threads: \n' + String.join(recordIds, ', '),
@@ -49,5 +52,34 @@ public without sharing class NKS_ThreadSharingEventHandler extends RecordSharing
         } finally {
             logger.publish();
         }
+    }
+    private static List<Thread__c> getThreadsByIds(List<Id> threadIds) {
+        String queryString =
+            'SELECT Id, CRM_Account__c, CRM_Henvendelse_BehandlingsId__c, CRM_Office_Restriction__c, ' +
+            'CRM_Theme_Code__c, CRM_Theme_Group_Name__c, STO_Category__c, CRM_Theme__c, CRM_Thread_Type__c, ' +
+            (Test.isRunningTest() ? '' : 'HOT_ParticipantIds__c, ') +
+            'CRM_Related_Object__c ' +
+            'FROM Thread__c ' +
+            'WHERE Id IN :threadIds';
+        return (List<Thread__c>) Database.queryWithBinds(
+            queryString,
+            new Map<String, Object>{ 'threadIds' => threadIds },
+            AccessLevel.SYSTEM_MODE
+        );
+    }
+    private void processTolkThreads(List<Thread__c> threads) {
+        Type hotThreadHandlerType = Type.forName('HOT_ThreadHandler');
+        if (hotThreadHandlerType == null || !Callable.class.isAssignableFrom(hotThreadHandlerType)) {
+            logger.critical(
+                'HOT_ThreadHandler class not found or not Callable:\n' +
+                String.join(new List<Id>(new Map<Id, Thread__c>(threads).keySet()), ', '),
+                null,
+                CRM_ApplicationDomain.Domain.HOT
+            );
+            return;
+        }
+        Callable hotThreadHandler = (Callable) hotThreadHandlerType.newInstance();
+        Map<String, List<Thread__c>> params = new Map<String, List<Thread__c>>{ 'threads' => threads };
+        hotThreadHandler.call('setInterpreter', params);
     }
 }


### PR DESCRIPTION
Part of fix for https://jira.adeo.no/browse/TOLK-3134.
On thread creation by community user it is not possible to run manual sharing in user context. Sharing should be triggered by platform event.
Added RecordSharingEvent creation on HOT-BRUKER_TOLK Threads
Added processing of these threads by an external class HOT_ThreadHandler from crm-hot-tolk.
As HOT-ParticipantIds field is declared in tolk repo, converted SOQL to dynamic query.